### PR TITLE
[WIP] Allow partial-checkout from clone time

### DIFF
--- a/GSD/GSD.Build/GSD.props
+++ b/GSD/GSD.Build/GSD.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GSDVersion>0.2.173.2</GSDVersion>
-    <GitPackageVersion>2.20190724.1</GitPackageVersion>
+    <GitPackageVersion>2.20190726.4-pr</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GSD/GSD.Common/GSDConstants.cs
+++ b/GSD/GSD.Common/GSDConstants.cs
@@ -168,9 +168,11 @@ namespace GSD.Common
                 public const string ExcludeName = "exclude";
                 public const string AlwaysExcludeName = "always_exclude";
                 public const string SparseCheckoutName = "sparse-checkout";
+                public const string PartialCheckoutName = "partial-checkout";
 
                 public static readonly string Root = Path.Combine(DotGit.Root, Info.Name);
                 public static readonly string SparseCheckoutPath = Path.Combine(Info.Root, Info.SparseCheckoutName);
+                public static readonly string PartialCheckoutPath = Path.Combine(Info.Root, Info.PartialCheckoutName);
                 public static readonly string ExcludePath = Path.Combine(Info.Root, ExcludeName);
                 public static readonly string AlwaysExcludePath = Path.Combine(Info.Root, AlwaysExcludeName);
             }

--- a/GSD/GSD.Common/Git/GitProcess.cs
+++ b/GSD/GSD.Common/Git/GitProcess.cs
@@ -458,6 +458,11 @@ namespace GSD.Common.Git
             return this.InvokeGitAgainstDotGitFolder("diff-tree -r -t " + sourceTreeish + " " + targetTreeish, null, onResult);
         }
 
+        public Result PartialCheckoutInit()
+        {
+            return this.InvokeGitAgainstDotGitFolder("partial-checkout init");
+        }
+
         public Result CreateBranchWithUpstream(string branchToCreate, string upstreamBranch)
         {
             return this.InvokeGitAgainstDotGitFolder("branch " + branchToCreate + " --track " + upstreamBranch);

--- a/GSD/GSD/CommandLine/CloneVerb.cs
+++ b/GSD/GSD/CommandLine/CloneVerb.cs
@@ -9,7 +9,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace GSD.CommandLine
 {
@@ -73,6 +72,13 @@ namespace GSD.CommandLine
             Required = false,
             HelpText = "Use this option to override the path for the local GSD cache.")]
         public string LocalCacheRoot { get; set; }
+
+        [Option(
+            "partial",
+            Required = false,
+            Default = false,
+            HelpText = "Initialize a partial-checkout to reduce hydration. Use 'git partial-checkout add' to expand cone.")]
+        public bool Partial { get; set; }
 
         protected override string VerbName
         {
@@ -139,6 +145,7 @@ namespace GSD.CommandLine
                                 { "SingleBranch", this.SingleBranch },
                                 { "NoMount", this.NoMount },
                                 { "NoPrefetch", this.NoPrefetch },
+                                { "Partial", this.Partial },
                                 { "Unattended", this.Unattended },
                                 { "IsElevated", GSDPlatform.Instance.IsElevated() },
                                 { "NamedPipeName", enlistment.NamedPipeName },
@@ -652,6 +659,12 @@ git %*
             File.WriteAllText(
                 Path.Combine(repoPath, GSDConstants.DotGit.PackedRefs),
                 refs.ToPackedRefs());
+
+            if (this.Partial)
+            {
+                GitProcess process = new GitProcess(enlistmentToInit);
+                process.PartialCheckoutInit();
+            }
 
             return new Result(true);
         }


### PR DESCRIPTION
To test:

```
$ gsd clone --partial https://github.com/microsoft/vfsforgit.git
$ cd vfsforgit.git/src
$ ls
AuthoringTests.md  CONTRIBUTING.md  GvFlt_EULA.md  GVFS.sln  License.md  nuget.config  Protocol.md  Readme.md  ThirdPartyNotices.txt
$ git partial-checkout add
GVFS/GVFS.Common
GVFS/GVFS.UnitTests
GitHooksLoader
^D
$ ls
AuthoringTests.md  GitHooksLoader/  GVFS/     License.md    Protocol.md  ThirdPartyNotices.txt
CONTRIBUTING.md    GvFlt_EULA.md    GVFS.sln  nuget.config  Readme.md
```

(Note: currently using stdin for `git partial-checkout add` seems to hang, but redirecting a file works. Keep that in mind.)

Uses microsoft/git#163, which is definitely in flux at the moment.